### PR TITLE
account for tags from patcher; get latest base tag from a previous commit

### DIFF
--- a/getparent.py
+++ b/getparent.py
@@ -90,6 +90,12 @@ def getparent(check_tags):
 
 	base_tag = git.describe('--tags', 'HEAD', '--abbrev=0')
 
+	if base_tag.find('fix-pack-fix-') > -1:
+		base_tag = git.tag('--merged', current_branch, '--sort', "-refname", "--list", "fix-pack-base-*", "--list", "fix-pack-de-*", "--list", "*-ga*")
+		
+		if base_tag:
+			base_tag = base_tag.split()[0]
+
 	if base_tag.find('fix-pack-base-') > -1 or base_tag.find('fix-pack-de-') > -1 or base_tag.find('-ga') > -1:
 		return base_tag
 

--- a/git.py
+++ b/git.py
@@ -55,6 +55,9 @@ def rev_parse(*args, **kwargs):
 def show(*args, **kwargs):
 	return _git('show', args, **kwargs)
 
+def tag(*args, **kwargs):
+	return _git('tag', args, **kwargs)
+
 git_root = rev_parse('--show-toplevel', stderr=DEVNULL)
 
 if git_root is None or git_root == '':


### PR DESCRIPTION
Hey @holatuwol,

This pr is for retrieving the proper base tag, such as **fix-pack-de-32-7010**, when working with a branch that was checked out from a **fix-pack-fix-*** tag.

Please let me know if you have any questions.
Thanks!