### PR TITLE
Fix font-weight

### DIFF
--- a/userscripts/zendesk.user.js
+++ b/userscripts/zendesk.user.js
@@ -57,7 +57,7 @@ a.generating::after {
 }
 
 .lesa-ui-description {
-  font-weight: 100;
+  font-weight: normal;
 }
 
 .lesa-ui-description .zd-comment {


### PR DESCRIPTION
Using `font-weight: 100` makes description text unreadable in case of some font-families. Setting it to `normal` makes it readable.