### PR TITLE
Fix readme to account for location of checktags

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ Then, add this section to ``.bash_aliases`` (or the equivalent on whichever shel
 	MCD_RD_CLONE_PATH=/path/to/clone/location
 
 	checktags() {
-		${MCD_RD_CLONE_PATH}/checktags
+		${MCD_RD_CLONE_PATH}/github/checktags
 	}
 
 	dbjar() {


### PR DESCRIPTION
Hi Minhchau! Wasn't sure if you preferred it in this README or the one in /github/, but just fixed it in place since this is its initial location.