### PR TITLE
github_link_jira.user.js is not correctly adding the JIRA links in the PR title

### DIFF
--- a/userscripts/github_link_jira.user.js
+++ b/userscripts/github_link_jira.user.js
@@ -42,6 +42,7 @@ var projects = {
   'LCP': 'services.liferay.com',
   'LPP': 'issues.liferay.com',
   'LPS': 'issues.liferay.com',
+  'LRAC': 'issues.liferay.com',
   'LRCI': 'issues.liferay.com',
   'LRDOCS': 'issues.liferay.com',
   'LRQA': 'issues.liferay.com'

--- a/userscripts/github_link_jira.user.js
+++ b/userscripts/github_link_jira.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           GitHub Link to LPS Tickets
 // @namespace      holatuwol
-// @version        2.0
+// @version        2.1
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/github_link_jira.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/github_link_jira.user.js
 // @match          https://github.com/LiferayCloud/*

--- a/userscripts/github_link_jira.user.js
+++ b/userscripts/github_link_jira.user.js
@@ -158,7 +158,7 @@ function checkCurrentURL() {
 
   replaceLinks(document.querySelectorAll(selectorString));
 
-  selector = ['span.js-issue-title','p.commit-title','.comment-body'];
+  selector = ['.js-issue-title','p.commit-title','.comment-body'];
   selectorString = selector.map(x => x + ':not([data-link-replaced="true"])').join(',');
 
   addJiraLinks(document.querySelectorAll(selectorString));


### PR DESCRIPTION
Hi @holatuwol 

github_link_jira.user.js is not correctly replacing the link in the PR title, span.js-issue-title selector no longer works because tje title is now include in a <bdi> element.

I am also adding the LRAC Analytics Cloud project to JIRA project list.
