### PR TITLE
Restore old ticket status column, change "Open-Pending" status color and restore old 'Closed' status

### DIFF
--- a/userscripts/zendesk.user.js
+++ b/userscripts/zendesk.user.js
@@ -116,14 +116,6 @@ function getJiraSearchLink(text, ticketId) {
 var accountCodeCache = {};
 var organizationCache = {};
 var ticketInfoCache = {};
-var CUSTOM_FIELD_CHILD_OF = 360013377052;
-/**
- * Returns the custom field value
- */
-function getCustomFieldValue(ticketInfo, fieldId) {
-    var matchingFields = ticketInfo.ticket.custom_fields.filter(function (it) { return it.id == fieldId; });
-    return matchingFields.length == 0 ? null : matchingFields[0].value;
-}
 var accountInfo = null;
 /**
  * Retrieve the account code from the sidebar.
@@ -1047,6 +1039,7 @@ function createAttachmentsContainer(ticketId, ticketInfo, conversation) {
     }
     return attachmentsContainer;
 }
+var CUSTOM_FIELD_CHILD_OF = 360013377052;
 /**
  * Add a sort button.
  */
@@ -1184,6 +1177,13 @@ function isDummyComment(ticketInfo, comment) {
         return true;
     }
     return false;
+}
+/**
+ * Returns the custom field value
+ */
+function getCustomFieldValue(ticketInfo, fieldId) {
+    var matchingFields = ticketInfo.ticket.custom_fields.filter(function (it) { return it.id == fieldId; });
+    return matchingFields.length == 0 ? null : matchingFields[0].value;
 }
 /**
  * Add a ticket description and a complete list of attachments to the top of the page.
@@ -2158,7 +2158,7 @@ function addArticleFormattingButtons(tinymce) {
     var preButtons = Array.from(document.querySelectorAll('div[data-test-id="toolbarPreButton"]'));
     for (var i = 0; i < preButtons.length; i++) {
         var toolbar = preButtons[i].parentElement;
-        if (toolbar.classList.contains('lesa-ui-stackedit')) {
+        if (toolbar == null || toolbar.classList.contains('lesa-ui-stackedit')) {
             continue;
         }
         toolbar.classList.add('lesa-ui-stackedit');

--- a/userscripts/zendesk.user.js
+++ b/userscripts/zendesk.user.js
@@ -2415,15 +2415,24 @@ function oldTicketStatusColumn() {
     }
 }
 function updateBadge(badge) {
-    /* Change badge colors for Open-Pending */
-    if (badge.textContent === 'Open-Pending') {
-        badge.style.setProperty("background-color", "#c782fc", "important");
+    /* Change badge colors for Open-Pending to purple */
+    if ((badge.textContent === 'Open-Pending' || badge.textContent === 'OP')) {
+        if (!badge.getAttribute('updated-open-color')) {
+            badge.style.setProperty("background-color", "#c782fc", "important");
+            badge.setAttribute('updated-open-color', "true");
+        }
+    }
+    /* Restore badge color if changing from Open-Pending to any other status */
+    else if (badge.getAttribute('updated-open-color')) {
+        badge.style.removeProperty("background-color");
+        badge.removeAttribute('updated-open-color');
     }
     /* Closed status was lost now is shown as Resolved, we can get it again from badge attributes */
-    else if ((badge.getAttribute('data-test-id') === 'status-badge-closed') || badge.classList.contains('closed')) {
+    else if (!badge.getAttribute('updated-closed-color') && ((badge.getAttribute('data-test-id') === 'status-badge-closed') || badge.classList.contains('closed'))) {
         badge.style.setProperty("background-color", "#dcdee0", "important");
         badge.style.setProperty("color", "#04363d", "important");
         badge.textContent = 'Closed';
+        badge.setAttribute('updated-closed-color', "true");
     }
 }
 function isBadgeInPopup(badge) {

--- a/userscripts/zendesk.user.js
+++ b/userscripts/zendesk.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        16.3
+// @version        16.4
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/
@@ -2350,6 +2350,104 @@ function checkForSubtitles() {
         checkTicket(ticketId, updateSubtitle.bind(null, title, subtitle));
     }
 }
+/**
+ * Set the old compact ticket status column style and change "Open-Pending" color to differenciate it from the "Open" one
+ * For more information, see https://liferay.slack.com/archives/CL8DNJYB0/p1675440794494529
+ */
+function oldTicketStatusColumn() {
+    var viewPage = ((unsafeWindow.location.pathname.indexOf('/agent/filters') == 0) || (unsafeWindow.location.pathname.indexOf('/agent/dashboard') == 0));
+    /* update status column */
+    var badges = Array.from(document.querySelectorAll('div[data-cy-test-id="status-badge-state"]'));
+    for (var _i = 0, badges_1 = badges; _i < badges_1.length; _i++) {
+        var badge = badges_1[_i];
+        updateBadge(badge);
+        /* Change the status text to the abreviate form only if we are in a view page and we are not in a popup */
+        if (viewPage && badge.textContent && (badge.textContent.length > 2) && (badge.textContent[0] != ' ') && !isBadgeInPopup(badge)) {
+            if (badge.textContent === 'On-hold') {
+                badge.textContent = ' H ';
+            }
+            else if (badge.textContent === 'Open-Pending') {
+                badge.textContent = 'OP';
+            }
+            else {
+                badge.textContent = ' ' + badge.textContent[0] + ' ';
+            }
+        }
+    }
+    /* Update Open-Pending badge color inside the ticket */
+    var ticketBadges = Array.from(document.querySelectorAll('span.ticket_status_label'));
+    for (var _a = 0, ticketBadges_1 = ticketBadges; _a < ticketBadges_1.length; _a++) {
+        var badge = ticketBadges_1[_a];
+        updateBadge(badge);
+    }
+    if (!viewPage) {
+        return;
+    }
+    /* remove "Ticket status" text from headers */
+    var headers = Array.from(document.querySelectorAll('th[data-garden-id="tables.header_cell"]:not([processed="true"]'));
+    for (var _b = 0, headers_1 = headers; _b < headers_1.length; _b++) {
+        var header = headers_1[_b];
+        header.setAttribute('processed', 'true');
+    }
+    if (headers[3] !== undefined) {
+        headers[3].textContent = '';
+    }
+    /* remove the padding of second column */
+    var secondColumn = Array.from(document.querySelectorAll('td.sc-15v8wy4-1:not([processed="true"]'));
+    for (var _c = 0, secondColumn_1 = secondColumn; _c < secondColumn_1.length; _c++) {
+        var cell = secondColumn_1[_c];
+        cell.style.paddingLeft = '0px';
+        cell.style.paddingRight = '2px';
+        cell.setAttribute('processed', 'true');
+    }
+    if (headers[1] !== undefined) {
+        headers[1].style.paddingLeft = '0px';
+        headers[1].style.paddingRight = '2px';
+    }
+    /* remove empty third column */
+    var thirdColumn = Array.from(document.querySelectorAll('td.oeot8n-0'));
+    for (var _d = 0, thirdColumn_1 = thirdColumn; _d < thirdColumn_1.length; _d++) {
+        var cell = thirdColumn_1[_d];
+        cell.remove();
+    }
+    if (headers[2] !== undefined) {
+        headers[2].remove();
+    }
+}
+function updateBadge(badge) {
+    /* Change badge colors for Open-Pending */
+    if (badge.textContent === 'Open-Pending') {
+        badge.style.setProperty("background-color", "#c782fc", "important");
+    }
+    /* Closed status was lost now is shown as Resolved, we can get it again from badge attributes */
+    else if ((badge.getAttribute('data-test-id') === 'status-badge-closed') || badge.classList.contains('closed')) {
+        badge.style.setProperty("background-color", "#dcdee0", "important");
+        badge.style.setProperty("color", "#04363d", "important");
+        badge.textContent = 'Closed';
+    }
+}
+function isBadgeInPopup(badge) {
+    if (!badge.parentElement) {
+        return false;
+    }
+    var grandParent = badge.parentElement.parentElement;
+    if (!grandParent) {
+        return false;
+    }
+    if (grandParent.getAttribute('data-test-id') === "ticket_table_tooltip-header-ticket-info") {
+        return true;
+    }
+    if (!grandParent.parentElement) {
+        return false;
+    }
+    if (grandParent.parentElement.getAttribute('data-test-id') === "header-tab-tooltip") {
+        return true;
+    }
+    if (grandParent.parentElement.getAttribute('data-cy-test-id') === "submit_button-menu") {
+        return true;
+    }
+    return false;
+}
 // Since there's an SPA framework in place that I don't fully understand,
 // attempt to do everything once per second.
 if (unsafeWindow.location.hostname.indexOf('zendesk.com') != -1) {
@@ -2359,5 +2457,6 @@ if (unsafeWindow.location.hostname.indexOf('zendesk.com') != -1) {
         setInterval(checkSidebarTags, 1000);
         setInterval(fixAttachmentLinks, 1000);
         setInterval(makeDraggableModals, 1000);
+        setInterval(oldTicketStatusColumn, 1000);
     }
 }


### PR DESCRIPTION
Hi @holatuwol

After https://liferay.slack.com/archives/CL8DNJYB0/p1675440794494529 changes, a new "Open-Pending" status was added to zendesk. This causes some problems to the user interface, for more information see https://github.com/holatuwol/liferay-zendesk-userscript/pull/9

In this PR I am copying the generated `userscripts/zendesk.user.js` file from https://github.com/holatuwol/liferay-zendesk-userscript/pull/9 after applying my changes and executing `./build.sh`

**Note:** there are some additional changes because https://github.com/holatuwol/liferay-faster-deploy/commit/387a0b191b8e655bc933aaa804542ab82070d00b code wasn't applied to liferay-zendesk-userscript repo, so after applying these changes, CUSTOM_FIELD_CHILD_OF constant and getCustomFieldValue was moved to a different place and I added a null check to avoid a typescript error.

Let me know if you have any question.


