### PR TITLE
Optimize gd and fix osx bug

### DIFF
--- a/appserverprops
+++ b/appserverprops
@@ -169,9 +169,9 @@ cleanappserver() {
 
 	if [ -f "${LIFERAY_HOME}/${TOMCAT_FOLDER}/conf/catalina.properties" ] && [ "" == "$(grep -F /ext/ ${LIFERAY_HOME}/${TOMCAT_FOLDER}/conf/catalina.properties)" ]; then
 		if [ "" != "$(grep -F 'common.loader="' ${LIFERAY_HOME}/${TOMCAT_FOLDER}/conf/catalina.properties)" ]; then
-			sed -i 's#common.loader=#common.loader="${catalina.base}/lib/ext/*.jar",#g' ${LIFERAY_HOME}/${TOMCAT_FOLDER}/conf/catalina.properties
+			sed -i.bak 's#common.loader=#common.loader="${catalina.base}/lib/ext/*.jar",#g' ${LIFERAY_HOME}/${TOMCAT_FOLDER}/conf/catalina.properties
 		else
-			sed -i 's#common.loader=#common.loader=${catalina.base}/lib/ext/*.jar,#g' ${LIFERAY_HOME}/${TOMCAT_FOLDER}/conf/catalina.properties
+			sed -i.bak 's#common.loader=#common.loader=${catalina.base}/lib/ext/*.jar,#g' ${LIFERAY_HOME}/${TOMCAT_FOLDER}/conf/catalina.properties
 		fi
 	fi
 }


### PR DESCRIPTION
Hey @holatuwol ,

This PR:
- Fixes an issue when using the script in OSX
- Optimizes gd
  - I noticed that the same artifact property may be evaluated multiple times
  - This change makes it so that we retrieve the hash only once per artifact property (since the git log command can take awhile, which can slowly add up)


**Additional Test Notes**
Regarding the gd optimization, for my testing I used the module: dynamic-data-mapping-form-field-type
- Checking the time it took to execute: project_to_library
  - Without changes: ~1m8s
  - With changes: ~43s

Feel free to let me know if you have any questions.
Thanks!