### PR TITLE
Zendesk script: Update link to the customer information to the new Customer Portal 2.0

### DIFF
--- a/userscripts/zendesk.user.js
+++ b/userscripts/zendesk.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name           ZenDesk for TSEs
 // @namespace      holatuwol
-// @version        16.6
+// @version        16.7
 // @updateURL      https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @downloadURL    https://raw.githubusercontent.com/holatuwol/liferay-faster-deploy/master/userscripts/zendesk.user.js
 // @include        /https:\/\/liferay-?support[0-9]*.zendesk.com\/agent\/.*/
@@ -584,15 +584,6 @@ function generateFormField(propertyBox, className, labelText, formElements) {
     propertyBox.appendChild(formField);
 }
 /**
- * Generate a URL to Customer Portal's account details view.
- */
-function getCustomerPortalAccountsHREF(params) {
-    var portletId = 'com_liferay_osb_customer_account_entry_details_web_AccountEntryDetailsPortlet';
-    var ns = '_' + portletId + '_';
-    var queryString = Object.keys(params).map(function (key) { return (key.indexOf('p_p_') == 0 ? key : (ns + key)) + '=' + encodeURIComponent(params[key]); }).join('&');
-    return 'https://customer.liferay.com/project-details?p_p_id=' + portletId + '&' + queryString;
-}
-/**
  * Add the Organization field to the sidebar, which will contain a link to Help Center
  * for the account details and the customer's SLA level.
  */
@@ -621,15 +612,8 @@ function addOrganizationField(propertyBox, ticketId, ticketInfo) {
     if (organizationInfo) {
         var organizationFields = organizationInfo.organization_fields;
         serviceLevel.push(organizationFields.sla.toUpperCase());
-        helpCenterLinkHREF = getCustomerPortalAccountsHREF({
-            mvcRenderCommandName: '/view_account_entry',
-            accountEntryId: organizationInfo.external_id
-        });
-    }
-    else if (accountCode) {
-        helpCenterLinkHREF = getCustomerPortalAccountsHREF({
-            keywords: accountCode
-        });
+        helpCenterLinkHREF = "https://support.liferay.com/project/#/" +
+            organizationInfo.organization_fields.account_key;
     }
     var helpCenterItems = [];
     if (accountCode && helpCenterLinkHREF) {


### PR DESCRIPTION
Hi @holatuwol 

Some weeks ago, the new Customer Portal 2.0 was released, see announcement: https://liferay.slack.com/archives/CJ1ERLHUZ/p1680102554868519

Now the customer information is located in the URL https://support.liferay.com/project/#/KOR-nnnnnnnn

In this PR I am copying the generated `userscripts/zendesk.user.js` file from https://github.com/holatuwol/liferay-zendesk-userscript/pull/10 after applying my changes and executing `./build.sh`

Let me know if you have any question.
